### PR TITLE
Migrate to PowerDNS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+sdk/** linguist-generated

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ cilium.yaml
 secrets.yaml
 
 vendor/
+
+# Dagger
+sdk/

--- a/dns/cfg/kgb33.dev.zone
+++ b/dns/cfg/kgb33.dev.zone
@@ -1,0 +1,21 @@
+$ORIGIN kgb33.dev.
+$TTL 1m
+
+pve IN SOA ns1.kgb33.dev. contact.kgb33.dev. (
+           0            ; serial
+           4h           ; refresh
+           15m          ; retry
+           8h           ; expire
+           1m)          ; negative caching TTL
+    IN NS ns1.kgb33.dev.
+    IN A  10.0.8.53
+
+$ORIGIN pve.kgb33.dev.
+
+glint    IN A 10.0.9.101
+targe    IN A 10.0.9.102
+sundance IN A 10.0.9.103
+
+$ORIGIN k8s.kgb33.dev.
+
+traefik  IN A 10.0.8.137

--- a/dns/cfg/named.conf
+++ b/dns/cfg/named.conf
@@ -1,0 +1,7 @@
+zone "kgb33.dev." {
+    type master;
+
+    file "kgb33.dev.zone";
+
+    allow-update { none; };
+};

--- a/dns/cfg/named.conf
+++ b/dns/cfg/named.conf
@@ -1,3 +1,7 @@
+options {
+    directory "/etc/powerdns/bind";
+};
+
 zone "kgb33.dev." {
     type master;
 

--- a/dns/cfg/pdns.conf
+++ b/dns/cfg/pdns.conf
@@ -1,0 +1,4 @@
+local-address=0.0.0.0:5353
+launch=bind
+bind-config=/etc/powerdns/bind/named.conf
+include-dir=/etc/powerdns/pdns.d

--- a/dns/cfg/recursor.yaml
+++ b/dns/cfg/recursor.yaml
@@ -5,4 +5,4 @@ recursor:
   forward_zones:
     - zone: kgb33.dev
       forwarders: 
-      - 10.0.8.53:53
+      - 10.0.8.53

--- a/dns/cfg/recursor.yaml
+++ b/dns/cfg/recursor.yaml
@@ -1,0 +1,8 @@
+incoming:
+  listen:
+    - '0.0.0.0:5353'
+recursor:
+  forward_zones:
+    - zone: kgb33.dev
+      forwarders: 
+      - 10.0.8.53:53

--- a/dns/dagger.json
+++ b/dns/dagger.json
@@ -1,0 +1,6 @@
+{
+  "name": "PowerDNS",
+  "sdk": "python",
+  "source": ".",
+  "engineVersion": "v0.9.10"
+}

--- a/dns/pyproject.toml
+++ b/dns/pyproject.toml
@@ -1,0 +1,3 @@
+[project]
+name = "main"
+version = "0.0.0"

--- a/dns/src/main.py
+++ b/dns/src/main.py
@@ -1,0 +1,50 @@
+from typing import Self
+import dagger
+from dagger import dag, function, object_type, field
+
+
+@object_type
+class PowerDNS:
+    # Foo
+    cfg: dagger.Directory = field()
+
+    @classmethod
+    async def create(cls, cfg: dagger.Directory | None = None) -> Self:
+        if cfg is None:
+            cfg = await dag.current_module().source().directory("cfg")
+        return cls(cfg=cfg)
+
+    @function
+    def cli(self) -> dagger.Terminal:
+        return (
+            dag.container()
+            .from_("alpine")
+            .with_exec(["apk", "add", "drill", "nmap"])
+            .with_service_binding("resolver", self.base_resolver().as_service())
+            .terminal()
+        )
+
+    @function
+    def base_resolver(self) -> dagger.Container:
+        return (
+            dag.container()
+            .from_("powerdns/pdns-recursor-master")
+            .with_file("/etc/powerdns/recursor.yml", self.cfg.file("recursor.yaml"))
+            .with_exposed_port(5353, protocol=dagger.NetworkProtocol.TCP)
+            # .with_exposed_port(5353, protocol=dagger.NetworkProtocol.UDP)
+            .with_service_binding("auth", self.base_auth().as_service())
+        )
+
+    @function
+    def base_auth(self) -> dagger.Container:
+        return (
+            dag.container()
+            .from_("powerdns/pdns-auth-master")
+            .with_file("/etc/powerdns/pdns.conf", self.cfg.file("pdns.conf"))
+            .with_exposed_port(5353, protocol=dagger.NetworkProtocol.TCP)
+            # .with_exposed_port(5353, protocol=dagger.NetworkProtocol.UDP)
+        )
+
+    @function
+    def base_dnsdist(self) -> dagger.Container:
+        return dag.container().from_("")

--- a/dns/src/main.py
+++ b/dns/src/main.py
@@ -31,7 +31,7 @@ class PowerDNS:
             .from_("powerdns/pdns-recursor-master")
             .with_file("/etc/powerdns/recursor.yml", self.cfg.file("recursor.yaml"))
             .with_exposed_port(5353, protocol=dagger.NetworkProtocol.TCP)
-            # .with_exposed_port(5353, protocol=dagger.NetworkProtocol.UDP)
+            .with_exposed_port(5353, protocol=dagger.NetworkProtocol.UDP)
             .with_service_binding("auth", self.base_auth().as_service())
         )
 
@@ -41,8 +41,12 @@ class PowerDNS:
             dag.container()
             .from_("powerdns/pdns-auth-master")
             .with_file("/etc/powerdns/pdns.conf", self.cfg.file("pdns.conf"))
+            .with_file("/etc/powerdns/bind/named.conf", self.cfg.file("named.conf"))
+            .with_file(
+                "/etc/powerdns/bind/kgb33.dev.zone", self.cfg.file("kgb33.dev.zone")
+            )
             .with_exposed_port(5353, protocol=dagger.NetworkProtocol.TCP)
-            # .with_exposed_port(5353, protocol=dagger.NetworkProtocol.UDP)
+            .with_exposed_port(5353, protocol=dagger.NetworkProtocol.UDP)
         )
 
     @function

--- a/flake.lock
+++ b/flake.lock
@@ -1,15 +1,35 @@
 {
   "nodes": {
+    "dagger": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1707821979,
+        "narHash": "sha256-V09c09iWxRND5bdGo0Q1b9WFn2h5FUktezIfTjdbbAM=",
+        "owner": "dagger",
+        "repo": "nix",
+        "rev": "c5640f0f1856a9fd9d523deab86d0e568c6c0137",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dagger",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
@@ -20,22 +40,23 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1697756275,
-        "narHash": "sha256-KAZ2F9He5oH2NPxhWDLmtGAsiBjPi7yps1OGZu6peMM=",
+        "lastModified": 1707689078,
+        "narHash": "sha256-UUGmRa84ZJHpGZ1WZEBEUOzaPOWG8LZ0yPg1pdDF/yM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d042a296139c6a111be3e3d5dc9ef6783b5e7c16",
+        "rev": "f9d39fb9aff0efee4a3d5f4a6d7c17701d38a1d8",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable-small",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
+        "dagger": "dagger",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,16 +2,18 @@
   description = "Homelab toolbox";
 
   inputs = {
-    nixpkgs = { url = "github:NixOS/nixpkgs/nixos-unstable-small"; };
+    nixpkgs = { url = "github:NixOS/nixpkgs/nixos-unstable"; };
     flake-utils = { url = "github:numtide/flake-utils"; };
+    dagger = {
+      url = "github:dagger/nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, flake-utils, dagger }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = nixpkgs.legacyPackages.${system};
-        pyPkgs = pkgs.python311Packages;
-
+        pkgs = import nixpkgs { inherit system; };
       in
       {
         # enable `nix fmt`
@@ -19,10 +21,15 @@
 
         devShell = pkgs.mkShell {
           buildInputs = [
-            pyPkgs.ansible-core
-            pyPkgs.ansible
-            pyPkgs.kubernetes
-            pkgs.ansible-lint
+            # tqdm does not work on Py-3.12
+            # https://github.com/tqdm/tqdm/issues/1537
+            # pkgs.python312Packages.ansible-core
+            # pkgs.python312Packages.ansible
+            # pkgs.python312Packages.kubernetes
+            # pkgs.ansible-lint
+
+            pkgs.python312
+            pkgs.black
             pkgs.opentofu
             pkgs.ansible-language-server
             pkgs.talosctl
@@ -35,6 +42,7 @@
             pkgs.jsonnet
             pkgs.jsonnet-bundler
             pkgs.just
+            dagger.packages.${system}.dagger
           ];
         };
 


### PR DESCRIPTION
Closes #15 

Currently running into issues daggerizing pdns. The resolver (rightfully) requires that the forwarder for a zone is specified as an IP address, which dagger cannot provide.

Additionally, Dagger cannot forward exposed UDP ports, which can make testing a bit more cumbersome.

 - [ ] Verify that the Authoritative server reads the Zone files correctly.
 - [ ] Reserve `10.0.8.XXX` addresses for the resolver and auth servers in MetalLB.
 - [ ] Configure Resolver s.t. it uses the above address for the forwarder.
 - [ ] Create ArgoCD Deployment
   - [ ] Remove PiHole
 - [ ] Write GH action to rebuild container when changes are made within the `dns/` folder.
 